### PR TITLE
__init__ should not return any value

### DIFF
--- a/coupons/forms.py
+++ b/coupons/forms.py
@@ -23,7 +23,7 @@ class CouponForm(forms.Form):
         if 'types' in kwargs:
             self.types = kwargs['types']
             del kwargs['types']
-        return super(CouponForm, self).__init__(*args, **kwargs)
+        super(CouponForm, self).__init__(*args, **kwargs)
 
     def clean_code(self):
         code = self.cleaned_data['code']


### PR DESCRIPTION
https://docs.python.org/2/reference/datamodel.html#object.__init__

```
"As a special constraint on constructors, no value may be returned; doing so will cause a TypeError to be raised at runtime."
```

While that may not technically happen here, because of the returned super, it should still be avoided.
