### PR TITLE
Adding support for Django 1.10

### DIFF
--- a/coupons/admin.py
+++ b/coupons/admin.py
@@ -34,7 +34,6 @@ class CouponAdmin(admin.ModelAdmin):
     def get_urls(self):
         urls = super(CouponAdmin, self).get_urls()
         my_urls = [
-            '',
             url(r'generate-coupons', self.admin_site.admin_view(GenerateCouponsAdminView.as_view()),
                 name='generate_coupons'),
 

--- a/coupons/admin.py
+++ b/coupons/admin.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib import admin
 from django.contrib import messages
 from django.utils.translation import ugettext_lazy as _
@@ -33,10 +33,12 @@ class CouponAdmin(admin.ModelAdmin):
 
     def get_urls(self):
         urls = super(CouponAdmin, self).get_urls()
-        my_urls = patterns(
+        my_urls = [
             '',
-            url(r'generate-coupons', self.admin_site.admin_view(GenerateCouponsAdminView.as_view()), name='generate_coupons'),
-        )
+            url(r'generate-coupons', self.admin_site.admin_view(GenerateCouponsAdminView.as_view()),
+                name='generate_coupons'),
+
+        ]
         return my_urls + urls
 
 


### PR DESCRIPTION
Fixed the admin urls with the new URLS syntax required for Django 1.10 (urlpatterns has been removed)