### PR TITLE
django.conf.urls.patterns removed in 1.10

### DIFF
--- a/coupons/admin.py
+++ b/coupons/admin.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib import admin
 from django.contrib import messages
 from django.utils.translation import ugettext_lazy as _
@@ -33,10 +33,9 @@ class CouponAdmin(admin.ModelAdmin):
 
     def get_urls(self):
         urls = super(CouponAdmin, self).get_urls()
-        my_urls = patterns(
-            '',
+        my_urls = [
             url(r'generate-coupons', self.admin_site.admin_view(GenerateCouponsAdminView.as_view()), name='generate_coupons'),
-        )
+        ]
         return my_urls + urls
 
 


### PR DESCRIPTION
django.conf.urls.patterns deprecated since 1.8 and removed in 1.10. 
Using simple array for 1.10 support. This will work for >= [1.8](https://docs.djangoproject.com/en/1.8/ref/urls/#patterns). 
Not sure about 1<= [1.7](https://docs.djangoproject.com/en/1.7/ref/urls/#patterns)

[https://docs.djangoproject.com/en/1.8/ref/urls/#patterns](https://docs.djangoproject.com/en/1.8/ref/urls/#patterns)