### PR TITLE
Fix issue with additional migrations being generated upon change of change of coupon types setting

### DIFF
--- a/coupons/migrations/0001_initial.py
+++ b/coupons/migrations/0001_initial.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('value', models.IntegerField(help_text='Arbitrary coupon value', verbose_name='Value')),
                 ('code', models.CharField(help_text='Leaving this field empty will generate a random code.', unique=True, max_length=30, verbose_name='Code', blank=True)),
-                ('type', models.CharField(max_length=20, verbose_name='Type', choices=[(b'monetary', b'Money based coupon'), (b'percentage', b'Percentage discount'), (b'virtual_currency', b'Virtual currency')])),
+                ('type', models.CharField(max_length=20, verbose_name='Type', choices=settings.COUPONS_COUPON_TYPES)),
                 ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Created at')),
                 ('redeemed_at', models.DateTimeField(null=True, verbose_name='Redeemed at', blank=True)),
                 ('user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, help_text='You may specify a user you want to restrict this coupon to.', null=True, verbose_name='User')),

--- a/coupons/migrations/0004_auto_20151105_1456.py
+++ b/coupons/migrations/0004_auto_20151105_1456.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='coupon',
             name='type',
-            field=models.CharField(choices=[('monetary', 'Money based coupon'), ('percentage', 'Percentage discount'), ('virtual_currency', 'Virtual currency')], verbose_name='Type', max_length=20),
+            field=models.CharField(choices=settings.COUPONS_COUPON_TYPES, verbose_name='Type', max_length=20),
         ),
         migrations.AddField(
             model_name='couponuser',


### PR DESCRIPTION
When generating migrations after changing the coupon types from settings, Django picks it up and creates a new migration in coupons app.

This is an unwanted side effect that should be avoided and easiest work around for now is to directly point migrations to settings.