### PR TITLE
Update travis and tox with newest Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,25 @@ install:
 script:
   - "tox"
 env:
+  - "TOXENV=py34-1.10.X"
+  - "TOXENV=py27-1.10.X"
+  - "TOXENV=py34-1.9.X"
+  - "TOXENV=py27-1.9.X"
   - "TOXENV=py34-1.8.X"
   - "TOXENV=py27-1.8.X"
   - "TOXENV=py34-1.7.X"
   - "TOXENV=py27-1.7.X"
   - "TOXENV=py34-1.6.X"
   - "TOXENV=py27-1.6.X"
+  - "TOXENV=py34-2.0.X"
+  - "TOXENV=py34-1.11.X"
+  - "TOXENV=py27-1.11.X"
+matrix:
+  allow_failures:
+  - env: "TOXENV=py34-2.0.X"
+  - env: "TOXENV=py34-1.11.X"
+  - env: "TOXENV=py27-1.11.X"
+  fast_finish: true
 cache:
   directories:
     - $HOME/.cache/pip

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,13 @@
 
 [tox]
 envlist =
+    py34-2.0.X,
+    py34-1.11.X,
+    py27-1.11.X,
+    py34-1.10.X,
+    py27-1.10.X,
+    py34-1.9.X,
+    py27-1.9.X,
     py34-1.8.X,
     py27-1.8.X,
     py34-1.7.X,
@@ -19,6 +26,41 @@ setenv =
 commands =
     django-admin.py --version
     django-admin.py test coupons
+
+[testenv:py34-2.0.X]
+basepython = python3.4
+deps =
+    django>=2.0, <2.1
+
+[testenv:py34-1.11.X]
+basepython = python3.4
+deps =
+    django>=1.11, <1.12
+
+[testenv:py27-1.11.X]
+basepython = python2.7
+deps =
+    django>=1.11, <1.12
+
+[testenv:py34-1.10.X]
+basepython = python3.4
+deps =
+    django>=1.10, <1.11
+
+[testenv:py27-1.10.X]
+basepython = python2.7
+deps =
+    django>=1.10, <1.11
+
+[testenv:py34-1.9.X]
+basepython = python3.4
+deps =
+    django>=1.9, <1.10
+
+[testenv:py27-1.9.X]
+basepython = python2.7
+deps =
+    django>=1.9, <1.10
 
 [testenv:py34-1.8.X]
 basepython = python3.4


### PR DESCRIPTION
Add Django versions from 1.9 to 2.0 to travis. 1.11 and 2.0 are allowed to fail since they are currently breaking the build.