### PR TITLE
Add "generate coupons" button linking to GenerateCouponsAdminView

### DIFF
--- a/coupons/templates/admin/coupons/coupon/change_list.html
+++ b/coupons/templates/admin/coupons/coupon/change_list.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_list.html" %}
+
+{% block object-tools-items %}
+    {{ block.super }}
+
+    <li>
+        <a href="generate-coupons/" class="grp-state-focus addlink">Generate coupons</a>
+    </li>
+{% endblock %}


### PR DESCRIPTION
In the coupon admin view, add a "generate coupons" button linking to `GenerateCouponsAdminView`. The button is shown next to the "Add Coupon" button as seen on the screenshot.

![image](https://user-images.githubusercontent.com/1280446/37916339-78ad696a-3113-11e8-95f8-97bd7dc15c1a.png)
